### PR TITLE
fix(ci): Add a CI step to set $PWD as a safe directory for Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
-      - run: make format && git diff --quiet
-      - run: make cppcheck
-      - run: make
+      - name: Set Git safe directory
+        run: git config --global --add safe.directory "$(pwd)"
+      - name: Ensure repository is formatted
+        run: make format && git diff --quiet
+      - name: Run static analysis
+        run: make cppcheck
+      - name: Build the repository
+        run: make


### PR DESCRIPTION
According to a comment on a GitLab form, this is because of ownership issues when running git commands (https://forum.gitlab.com/t/ci-cd-job-git-diff/76666/2).