### PR TITLE
chore(.gitignore): Exclude .vscode directory, generated by VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build/
 
 ### macOS ###
 .DS_Store
+
+### VS Code ###
+.vscode/


### PR DESCRIPTION
The .vscode directory is typically generated by VS Code and contains workspace-specific settings and configurations for the IDE.