### PR TITLE
fix(hal): Move SYSCLK definition to src/hal.h

### DIFF
--- a/src/hal.h
+++ b/src/hal.h
@@ -5,6 +5,10 @@
 #include <stdbool.h>
 
 // clang-format off
+#define SYSCLK              (4000000U)
+// clang-format on
+
+// clang-format off
 #define BIT(x)          (1UL << (x))
 #define PIN(bank, num)  ((((bank) - 'A') << 8) | (num))
 #define PINNO(pin)      (pin & 255)

--- a/src/main.c
+++ b/src/main.c
@@ -3,7 +3,6 @@
 #include <stdint.h>
 
 // clang-format off
-#define SYSCLK              (4000000U)
 #define SYSTICK_FREQUENCY   (1000U)
 // clang-format on
 


### PR DESCRIPTION
As SYSCLK is more closely related to the HAL and reusable in future HAL identifiers, move it from src/main.c to src/hal.h.