### PR TITLE
feat(printf): Use printf from newlib C library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ SOURCES_WITH_HEADERS = \
 
 SOURCES = \
 			$(MAIN_FILE) \
+			$(SRC_DIR)/startup.c \
+			$(SRC_DIR)/syscalls.c \
 			$(SOURCES_WITH_HEADERS)
 
 HEADERS = \

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include "hal.h"
 
 #include <stdint.h>
+#include <stdio.h>
 
 // clang-format off
 #define SYSTICK_FREQUENCY   (1000U)
@@ -10,12 +11,6 @@
 // clang-format on
 
 static volatile uint32_t systick_count;
-
-/**
- * @brief SysTick IRQ Handler.
- *
- */
-void SysTick_Handler(void);
 
 /**
  * @brief Precise millisecond clock for arbitrary periodic timers.
@@ -56,14 +51,8 @@ int main(void)
             gpio_write(led_user_1, on);
             gpio_write(led_user_2, !on);
 
-            if(on)
-            {
-                usart_write_buffer(USART_DEBUG, "LED 1: on\tLED 2: off\r\n", 22);
-            }
-            else
-            {
-                usart_write_buffer(USART_DEBUG, "LED 1: off\tLED 2: on\r\n", 22);
-            }
+            printf("LED 1: %d\tLED 2: %d\tsystick_count: %lu\r\n", on, !on,
+                   (unsigned long)systick_count);
         }
     }
 
@@ -100,44 +89,3 @@ bool timer_expired(uint32_t *t, const uint32_t prd, const uint32_t now)
     // timer expired, return true
     return true;
 }
-
-/**
- * @brief Reset interrupt handler with the startup code.
- *
- */
-__attribute__((naked, noreturn)) void _reset(void)
-{
-    // memset .bss to zero, and copy .data section to RAM region
-    extern long _sbss, _ebss, _sdata, _edata, _sidata;
-
-    for(long *dst = &_sbss; dst < &_ebss; dst++)  // cppcheck-suppress comparePointers
-    {
-        *dst = 0;
-    }
-
-    for(long *dst = &_sdata, *src = &_sidata; dst < &_edata;)
-    {
-        *dst++ = *src++;
-    }
-
-    main();
-
-    for(;;) (void)0;
-}
-
-// defined in link.ld
-extern void _estack(void);
-
-// clang-format off
-/**
- * @brief 16 standard and 95 STM32-specific handlers.
- *
- */
-__attribute__((section(".vectors"))) void (*const tab[16 + 95])(void) =
-{
-    _estack,
-    _reset,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    SysTick_Handler
-};
-// clang-format on

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,0 +1,55 @@
+/**
+ * @brief Application's entry point.
+ *
+ */
+extern int main(void);
+
+/**
+ * @brief Reset interrupt handler with the startup code.
+ *
+ */
+__attribute__((naked, noreturn)) void _reset(void)
+{
+    // memset .bss to zero, and copy .data section to RAM region
+    extern long _sbss, _ebss, _sdata, _edata, _sidata;
+
+    for(long *dst = &_sbss; dst < &_ebss; dst++)  // cppcheck-suppress comparePointers
+    {
+        *dst = 0;
+    }
+
+    for(long *dst = &_sdata, *src = &_sidata; dst < &_edata;)
+    {
+        *dst++ = *src++;
+    }
+
+    main();
+
+    for(;;) (void)0;
+}
+
+/**
+ * @brief Initial stack value at the end of SRAM region.
+ *
+ */
+extern void _estack(void);
+
+/**
+ * @brief SysTick IRQ handler.
+ *
+ */
+extern void SysTick_Handler(void);
+
+// clang-format off
+/**
+ * @brief 16 standard and 95 STM32-specific handlers.
+ *
+ */
+__attribute__((section(".vectors"))) void (*const tab[16 + 95])(void) =
+{
+    _estack,
+    _reset,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    SysTick_Handler
+};
+// clang-format on

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1,0 +1,113 @@
+#include "hal.h"
+
+#include <sys/stat.h>
+
+int _fstat(int fd, struct stat *st)
+{
+    if(fd < 0)
+    {
+        return -1;
+    }
+    st->st_mode = S_IFCHR;
+
+    return 0;
+}
+
+void *_sbrk(int incr)
+{
+    extern char _end;
+    static unsigned char *heap = NULL;
+    unsigned char *prev_heap;
+    if(NULL == heap)
+    {
+        heap = (unsigned char *)&_end;
+    }
+    prev_heap = heap;
+    heap += incr;
+
+    return prev_heap;
+}
+
+int _open(const char *path)
+{
+    (void)path;
+    return -1;
+}
+
+int _close(int fd)
+{
+    (void)fd;
+    return -1;
+}
+
+int _isatty(int fd)
+{
+    (void)fd;
+    return 1;
+}
+
+int _lseek(int fd, int ptr, int dir)
+{
+    (void)fd, (void)ptr, (void)dir;
+    return 0;
+}
+
+void _exit(int status)
+{
+    (void)status;
+    for(;;)
+    {
+        asm volatile("BKPT #0");
+    }
+}
+
+void _kill(int pid, int sig)
+{
+    (void)pid, (void)sig;
+}
+
+int _getpid(void)
+{
+    return -1;
+}
+
+int _write(int fd, char *ptr, int len)
+{
+    (void)fd, (void)ptr, (void)len;
+    if(1 == fd)
+    {
+        usart_write_buffer(USART1, ptr, (size_t)len);
+    }
+
+    return -1;
+}
+
+int _read(int fd, char *ptr, int len)
+{
+    (void)fd, (void)ptr, (void)len;
+    return -1;
+}
+
+int _link(const char *a, const char *b)
+{
+    (void)a, (void)b;
+    return -1;
+}
+
+int _unlink(const char *a)
+{
+    (void)a;
+    return -1;
+}
+
+int _stat(const char *path, struct stat *st)
+{
+    (void)path, (void)st;
+    return -1;
+}
+
+int mkdir(const char *path, mode_t mode)
+{
+    (void)path, (void)mode;
+    return -1;
+}


### PR DESCRIPTION
Replace usart_write_buffer() function calls with newlib's printf() function calls to enable formatted output. This enhances the ability to print diagnostic information, implementing "printf-style debugging".