### PR TITLE
feat(clock_config): Configure clocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ SOURCES = \
 			$(MAIN_FILE) \
 			$(CMSIS_L4_DIR)/Source/Templates/gcc/startup_stm32l4s5xx.s \
 			$(SRC_DIR)/syscalls.c \
+			$(SRC_DIR)/sysinit.c \
 			$(SOURCES_WITH_HEADERS)
 
 HEADERS = \

--- a/src/hal.h
+++ b/src/hal.h
@@ -8,18 +8,58 @@
 #include <stddef.h>
 
 // clang-format off
-#define SYSCLK_FREQ                 (4000000U)
-// clang-format on
+#define BIT(x)                          (1UL << (x))
+#define SETBITS(R, CLEARMASK, SETMASK)  (R) = (((R) & ~(CLEARMASK)) | (SETMASK))
+#define PIN(bank, num)                  ((((bank) - 'A') << 8) | (num))
+#define PINNO(pin)                      (pin & 255)
+#define PINBANK(pin)                    (pin >> 8)
 
-// clang-format off
-#define BIT(x)                      (1UL << (x))
-#define PIN(bank, num)              ((((bank) - 'A') << 8) | (num))
-#define PINNO(pin)                  (pin & 255)
-#define PINBANK(pin)                (pin >> 8)
+#define GPIO(bank)                      ((GPIO_TypeDef *) (0x48000000 + 0x400 * (bank)))
 
-#define GPIO(bank)                  ((GPIO_TypeDef *) (0x48000000 + 0x400 * (bank)))
+#define BYTE_MASK                       (0xFFU)
 
-#define BYTE_MASK                   (0xFFU)
+// 6.2: AHB clock <= 120MHz; APB1 clock <= 120MHz; APB2 clock <= 120MHz
+// 3.3.3, Table 12: Configure flash latency (WS) according to clock frequency
+
+// HSI clock frequency [MHz]
+#define HSI_CLK                         (16U)
+
+// run PLLCLK at 120MHz
+#define PLL_INPUT                       (HSI_CLK)
+
+// bit_field = PLL_M - 1
+#define PLL_M                           (2U)
+
+// bit_field = PLL_N = multiplication_factor
+#define PLL_N                           (30U)
+
+// bit_field = ((PLL_R - 2) / 2) & 3
+#define PLL_R                           (2U)
+
+// HCLK = SYSCLK
+#define AHB_HPRE                        (0U)
+
+// APB1 = AHB
+#define APB1_PPRE                       (0U)
+
+// APB2 = AHB
+#define APB2_PPRE                       (0U)
+
+// multiply by 1,000,000 as frequency is calculated in MHz
+#define SYS_FREQUENCY                   ((PLL_INPUT * PLL_N / PLL_M / PLL_R) * 1000000)
+#define FLASH_LATENCY                   (FLASH_ACR_LATENCY_5WS)
+
+#if 0 == APB1_PPRE
+    #define APB1_FREQUENCY              (SYS_FREQUENCY)
+#else
+    #define APB1_FREQUENCY              (SYS_FREQUENCY / BIT(APB1_PPRE - 3))
+#endif
+
+#if 0 == APB2_PPRE
+    #define APB2_FREQUENCY              (SYS_FREQUENCY)
+#else
+    #define APB2_FREQUENCY              (SYS_FREQUENCY / BIT(APB2_PPRE - 3))
+#endif
 // clang-format on
 
 /**
@@ -42,35 +82,89 @@ typedef enum
 } GPIO_Modes;
 
 /**
- * @brief Set GPIO pin's mode.
+ * @brief General Purpose I/O pin output types.
  *
- * @param pin           GPIO pin.
- * @param mode          GPIO pin's mode.
  */
-void gpio_set_mode(const uint16_t pin, const GPIO_Modes mode);
+typedef enum
+{
+    GPIO_OTYPE_PUSH_PULL,
+    GPIO_OTYPE_OPEN_DRAIN
+} GPIO_Output_Types;
 
 /**
- * @brief Set GPIO pin's alternate function.
+ * @brief General Purpose I/O pin output speeds.
+ *
+ */
+typedef enum
+{
+    GPIO_OSPEED_LOW,
+    GPIO_OSPEED_MEDIUM,
+    GPIO_OSPEED_HIGH,
+    GPIO_OSPEED_VERY_HIGH
+} GPIO_Output_Speeds;
+
+/**
+ * @brief General Purpose I/O pin pull-up/pull-down configuration.
+ *
+ */
+typedef enum
+{
+    GPIO_PUPDR_NONE,
+    GPIO_PUPDR_UP,
+    GPIO_PUPDR_DOWN
+} GPIO_Pull_Type;
+
+/**
+ * @brief Initialize GPIO pin.
  *
  * @param pin           GPIO pin.
- * @param af_num        GPIO pin's alternate function number as per datasheet (Table 16 and 17).
+ * @param mode          Pin's mode.
+ * @param output_type   Pin's output type.
+ * @param output_speed  Pin's output speed.
+ * @param pull_type     Pin's pull-up/pull-down configuration.
+ * @param alt_func_num  Pin's alternate function number as per datasheet (Table 16 and 17).
  */
-void gpio_set_af(const uint16_t pin, const uint8_t af_num);
+void gpio_init(const uint16_t pin, const GPIO_Modes mode, const GPIO_Output_Types output_type,
+               const GPIO_Output_Speeds output_speed, const GPIO_Pull_Type pull_type,
+               const uint8_t alt_func_num);
+
+/**
+ * @brief Initialize GPIO pin as an input pin.
+ *
+ * @param pin           GPIO pin.
+ */
+void gpio_input(const uint16_t pin);
+
+/**
+ * @brief Initialize GPIO pin as an output pin.
+ *
+ * @param pin           GPIO pin.
+ */
+void gpio_output(const uint16_t pin);
+
+/**
+ * @brief Read GPIO pin.
+ *
+ * @param pin           GPIO pin.
+ *
+ * @return `bool`       GPIO input state.
+ */
+bool gpio_read(const uint16_t pin);
+
+/**
+ * @brief Toggle GPIO pin output.
+ *
+ * @param pin           GPIO pin.
+ */
+void gpio_toggle(const uint16_t pin);
 
 /**
  * @brief Write to GPIO pin.
  *
  * @param pin           GPIO pin.
- * @param val           GPIO pin value.
+ * @param val           GPIO pin state.
  */
 void gpio_write(const uint16_t pin, const bool val);
-
-/**
- * @brief SysTick initialization.
- *
- * @param ticks         Number of clock periods before SysTick IRQ is triggered.
- */
-void systick_init(const uint32_t ticks);
 
 /**
  * @brief USART initialization.

--- a/src/main.c
+++ b/src/main.c
@@ -4,8 +4,6 @@
 #include <stdio.h>
 
 // clang-format off
-#define SYSTICK_FREQUENCY   (1000U)
-
 #define USART_DEBUG         (USART1)
 #define USART_BAUD_RATE     (115200U)
 // clang-format on
@@ -28,9 +26,9 @@ int main(void)
     uint16_t led_user_1 = PIN('A', 5);
     uint16_t led_user_2 = PIN('B', 14);
 
-    // set LEDs to output mode
-    gpio_set_mode(led_user_1, GPIO_MODE_OUTPUT);
-    gpio_set_mode(led_user_2, GPIO_MODE_OUTPUT);
+    // set LEDs' GPIO pins as output pins
+    gpio_output(led_user_1);
+    gpio_output(led_user_2);
 
     // initialize debug USART
     usart_init(USART_DEBUG, USART_BAUD_RATE);
@@ -54,15 +52,6 @@ int main(void)
     }
 
     return 0;
-}
-
-void SystemInit(void)
-{
-    // enable SYSCFG
-    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
-
-    // configure SysTick to trigger SysTick IRQ every 1ms
-    SysTick_Config(SYSCLK_FREQ / SYSTICK_FREQUENCY);
 }
 
 void SysTick_Handler(void)

--- a/src/sysinit.c
+++ b/src/sysinit.c
@@ -1,0 +1,69 @@
+#include "hal.h"
+
+// clang-format off
+#define SYSTICK_FREQUENCY   (1000U)
+// clang-format on
+
+void SystemInit(void)
+{
+    // enable coprocessors for FPU
+    SCB->CPACR |= ((3UL << 10 * 2) | (3UL << 11 * 2));
+
+    // configure for selecting Range1 boost mode
+    RCC->CFGR &= ~(RCC_CFGR_HPRE_Msk);
+    RCC->CFGR |= (8 << RCC_CFGR_HPRE_Pos) & RCC_CFGR_HPRE_Msk;
+    PWR->CR5 &= ~(PWR_CR5_R1MODE_Msk);
+
+    // set flash latency, and enable prefetch and instruction cache
+    FLASH->ACR |= FLASH_LATENCY | FLASH_ACR_PRFTEN | FLASH_ACR_ICEN;
+
+    // clear necessary PLLCFGR bits
+    RCC->PLLCFGR &= ~(RCC_PLLCFGR_PLLR_Msk | RCC_PLLCFGR_PLLREN_Msk | RCC_PLLCFGR_PLLN_Msk |
+                      RCC_PLLCFGR_PLLM_Msk | RCC_PLLCFGR_PLLSRC_Msk);
+
+    // set HSI16 as PLL entry clock source
+    RCC->PLLCFGR |= RCC_PLLCFGR_PLLSRC_HSI;
+
+    // set PLL_R, PLL_N, and PLL_M respectively
+    RCC->PLLCFGR |= (((PLL_R - 2) / 2) << RCC_PLLCFGR_PLLR_Pos) & RCC_PLLCFGR_PLLR_Msk;
+    RCC->PLLCFGR |= (PLL_N << RCC_PLLCFGR_PLLN_Pos) & RCC_PLLCFGR_PLLN_Msk;
+    RCC->PLLCFGR |= ((PLL_M - 1) << RCC_PLLCFGR_PLLM_Pos) & RCC_PLLCFGR_PLLM_Msk;
+
+    // enable PLLCLK output
+    RCC->PLLCFGR |= RCC_PLLCFGR_PLLREN;
+
+    // enable HSI and wait until it is ready
+    RCC->CR |= RCC_CR_HSION;
+    while(0 == (RCC->CR & RCC_CR_HSIRDY))
+    {
+        spin(1);
+    }
+
+    // enable PLL and wait until it is ready
+    RCC->CR |= RCC_CR_PLLON;
+    while(0 == (RCC->CR & RCC_CR_PLLRDY))
+    {
+        spin(1);
+    }
+
+    // clear necessary CFGR bits
+    RCC->CFGR &= ~(RCC_CFGR_HPRE_Msk | RCC_CFGR_PPRE1_Msk | RCC_CFGR_PPRE2_Msk);
+
+    // set AHB, APB1, and APB2 prescalers, respectively
+    RCC->CFGR |= (AHB_HPRE << RCC_CFGR_HPRE_Pos) & RCC_CFGR_HPRE_Msk;
+    RCC->CFGR |= (APB1_PPRE << RCC_CFGR_PPRE1_Pos) & RCC_CFGR_PPRE1_Msk;
+    RCC->CFGR |= (APB2_PPRE << RCC_CFGR_PPRE2_Pos) & RCC_CFGR_PPRE2_Msk;
+
+    // set PLL as system clock and wait until it starts being used
+    RCC->CFGR |= RCC_CFGR_SW_PLL;
+    while(RCC_CFGR_SWS_PLL != (RCC->CFGR & RCC_CFGR_SWS_Msk))
+    {
+        spin(1);
+    }
+
+    // enable SYSCFG
+    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+
+    // configure SysTick to trigger SysTick IRQ every 1ms
+    SysTick_Config(SYS_FREQUENCY / SYSTICK_FREQUENCY);
+}


### PR DESCRIPTION
Use HSI as clock source to maximize bus clock frequencies for AHB, APB1, and APB2 through PLL and other prescalers.